### PR TITLE
feat: introduce new infix operators

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -18,11 +18,13 @@ You need OCaml 4.14.0 or newer to enjoy the [experimental TMC feature](https://w
 ### OPAM
 
 The package is available in the OPAM repository:
+
 ```sh
 opam install bwd
 ```
 
 You can also pin the latest version in development:
+
 ```sh
 opam pin https://github.com/RedPRL/bwd.git
 ```
@@ -33,27 +35,27 @@ opam pin https://github.com/RedPRL/bwd.git
 open Bwd
 open Bwd.Infix
 
-(* [Emp] is the empty list and [#<] is snoc (cons in reverse).
+(* [Emp] is the empty list and [<:] is snoc (cons in reverse).
    The following expression gives the backward list corresponding to [1; 2; 3]. *)
-let b1 : int bwd = Emp #< 1 #< 2 #< 3
+let b1 : int bwd = Emp <: 1 <: 2 <: 3
 
 (* The module [Bwd] is similar to the standard [List] but for backward lists.
    It has most functions you would expect. For example, the following expression
-   gives the backward list corresponding to [2; 3; 4]. *)
-let b2 : int bwd = Bwd.map (fun x -> x + 1) b1
+   gives the backward list corresponding to [4; 5; 6]. *)
+let b2 : int bwd = Bwd.map (fun x -> x + 3) b1
 
 (* Same as above, but using [BwdLabels] that mimics [ListLabels] instead. *)
-let b2' : int bwd = BwdLabels.map ~f:(fun x -> x + 1) b1
+let b2' : int bwd = BwdLabels.map ~f:(fun x -> x + 3) b1
 
-(* bwd yoga 1: [<><] for moving elements from a forward list on the right
+(* bwd yoga 1: [<@] for moving elements from a forward list on the right
    to a backward list on the left. The notation was inspired by Conor McBride.
-   The following gives the backward list corresponding to [1; 2; 3; 4; 5; 6]. *)
-let b3 : int bwd = b1 <>< [4; 5; 6]
+   The following gives the backward list corresponding to [4; 5; 6; 7; 8; 9]. *)
+let b3 : int bwd = b2 <@ [7; 8] <@ [9]
 
-(* bwd yoga 2: [<>>] for moving elements from a backward list on the left
+(* bwd yoga 2: [@>] for moving elements from a backward list on the left
    to a forward list on the right. The notation was inspired by Conor McBride.
-   The following gives the forward list [1; 2; 3; 4; 5; 6; 7; 8; 9]. *)
-let l4 : int list = b3 <>> [7; 8; 9]
+   The following gives the forward list [1; 2; 3; 4; 5; 6; 7; 8; 9; 10]. *)
+let l4 : int list = b1 @> b3 @> [10]
 ```
 
 ## Philosophy

--- a/src/BwdLabels.mli
+++ b/src/BwdLabels.mli
@@ -103,13 +103,22 @@ val of_list : 'a list -> 'a t
 (** Notation inspired by Conor McBride. *)
 module Infix :
 sig
-  val (#<) : 'a t -> 'a -> 'a t
+  val (#<) : 'a t -> 'a -> 'a t [@@ocaml.alert deprecated "Use (<:) instead"]
   (** An alias of {!val:BwdLabels.snoc}. *)
 
-  val (<><) : 'a t -> 'a list -> 'a t
+  val (<><) : 'a t -> 'a list -> 'a t [@@ocaml.alert deprecated "Use (<@) instead"]
   (** An alias of {!val:BwdLabels.append}. *)
 
-  val (<>>) : 'a t -> 'a list -> 'a list
+  val (<>>) : 'a t -> 'a list -> 'a list [@@ocaml.alert deprecated "Use (@>) instead"]
+  (** An alias of {!val:BwdLabels.prepend}. *)
+
+  val (<:) : 'a t -> 'a -> 'a t
+  (** An alias of {!val:BwdLabels.snoc}. *)
+
+  val (<@) : 'a t -> 'a list -> 'a t
+  (** An alias of {!val:BwdLabels.append}. *)
+
+  val (@>) : 'a t -> 'a list -> 'a list
   (** An alias of {!val:BwdLabels.prepend}. *)
 end
 

--- a/src/BwdNoLabels.ml
+++ b/src/BwdNoLabels.ml
@@ -347,6 +347,9 @@ struct
   let (#<) = snoc
   let (<><) = append
   let (<>>) = prepend
+  let (<:) = snoc
+  let (<@) = append
+  let (@>) = prepend
 end
 
 module Notation = Infix

--- a/src/BwdNoLabels.mli
+++ b/src/BwdNoLabels.mli
@@ -103,13 +103,22 @@ val of_list : 'a list -> 'a t
 (** Notation inspired by Conor McBride. *)
 module Infix :
 sig
-  val (#<) : 'a t -> 'a -> 'a t
+  val (#<) : 'a t -> 'a -> 'a t [@@ocaml.alert deprecated "Use (<:) instead"]
   (** An alias of {!val:Bwd.snoc}. *)
 
-  val (<><) : 'a t -> 'a list -> 'a t
+  val (<><) : 'a t -> 'a list -> 'a t [@@ocaml.alert deprecated "Use (<@) instead"]
   (** An alias of {!val:Bwd.append}. *)
 
-  val (<>>) : 'a t -> 'a list -> 'a list
+  val (<>>) : 'a t -> 'a list -> 'a list [@@ocaml.alert deprecated "Use (@>) instead"]
+  (** An alias of {!val:Bwd.prepend}. *)
+
+  val (<:) : 'a t -> 'a -> 'a t
+  (** An alias of {!val:Bwd.snoc}. *)
+
+  val (<@) : 'a t -> 'a list -> 'a t
+  (** An alias of {!val:Bwd.append}. *)
+
+  val (@>) : 'a t -> 'a list -> 'a list
   (** An alias of {!val:Bwd.prepend}. *)
 end
 

--- a/test/ListAsBwdLabels.ml
+++ b/test/ListAsBwdLabels.ml
@@ -108,3 +108,7 @@ let of_list xs = xs
 let (#<) xs x = snoc xs x
 let (<>>) xs ys = prepend xs ys
 let (<><) xs ys = append xs ys
+
+let (<:) xs x = snoc xs x
+let (<@) xs ys = append xs ys
+let (@>) xs ys = prepend xs ys

--- a/test/TestBwdLabels.ml
+++ b/test/TestBwdLabels.ml
@@ -266,14 +266,29 @@ let test_of_list =
 let (#<) =
   Q.Test.make ~count ~name:"(#<)" Q.Gen.(pair (small_list int) int) ~print:Q.Print.(pair (list int) int)
     (fun (xs, x) -> to_list (B.Infix.(#<) (of_list xs) x) = L.(#<) xs x)
+  [@alert "-deprecated"]
 let (<><) =
   Q.Test.make ~count ~name:"(<><)" Q.Gen.(pair (small_list int) (small_list int))
     ~print:Q.Print.(pair (list int) (list int))
     (fun (xs, ys) -> to_list (B.Infix.(<><) (of_list xs) ys) = L.(<><) xs ys)
+  [@alert "-deprecated"]
 let (<>>) =
   Q.Test.make ~count ~name:"(<>>)" Q.Gen.(pair (small_list int) (small_list int))
     ~print:Q.Print.(pair (list int) (list int))
     (fun (xs, ys) -> B.Infix.(<>>) (of_list xs) ys = L.(<>>) xs ys)
+  [@alert "-deprecated"]
+
+let (<:) =
+  Q.Test.make ~count ~name:"(<:)" Q.Gen.(pair (small_list int) int) ~print:Q.Print.(pair (list int) int)
+    (fun (xs, x) -> to_list (B.Infix.(<:) (of_list xs) x) = L.(<:) xs x)
+let (<@) =
+  Q.Test.make ~count ~name:"(<@)" Q.Gen.(pair (small_list int) (small_list int))
+    ~print:Q.Print.(pair (list int) (list int))
+    (fun (xs, ys) -> to_list (B.Infix.(<@) (of_list xs) ys) = L.(<@) xs ys)
+let (@>) =
+  Q.Test.make ~count ~name:"(@>)" Q.Gen.(pair (small_list int) (small_list int))
+    ~print:Q.Print.(pair (list int) (list int))
+    (fun (xs, ys) -> B.Infix.(@>) (of_list xs) ys = L.(@>) xs ys)
 
 
 let () =
@@ -323,4 +338,7 @@ let () =
       (#<);
       (<><);
       (<>>);
+      (<:);
+      (<@);
+      (@>);
     ]


### PR DESCRIPTION
Just made a PR with the proposed symbols. The old ones are deprecated. @mikeshulman @jonsterling Closes #12.

- `<:` for "snoc": `Emp <: 1 <: 2 <: 3`.
  Previously, it's `#<`.
- `<@` for append: `Emp <@ [4; 5; 6] <@ [7; 8; 9]`.
  Previously, it's `<><`.
- `@>` for prepend: `b1 @> b2 @> [10]`.
  Previously, it's `<>>`.

Question: Should we keep mentioning Conor McBride for the new symbols?