### PR TITLE
feat: add back `concat` and `flatten`

### DIFF
--- a/src/BwdLabels.ml
+++ b/src/BwdLabels.ml
@@ -18,6 +18,10 @@ let append = BwdNoLabels.append
 
 let prepend = BwdNoLabels.prepend
 
+let concat = BwdNoLabels.concat
+
+let flatten = BwdNoLabels.flatten
+
 let[@inline] equal ~eq xs ys = BwdNoLabels.equal eq xs ys
 
 let[@inline] compare ~cmp xs ys = BwdNoLabels.compare cmp xs ys

--- a/src/BwdLabels.mli
+++ b/src/BwdLabels.mli
@@ -43,6 +43,8 @@ val nth : 'a t -> int -> 'a
 val nth_opt : 'a t -> int -> 'a option
 val append : 'a t -> 'a list -> 'a t
 val prepend : 'a t -> 'a list -> 'a list
+val concat : 'a t t -> 'a t
+val flatten : 'a t t -> 'a t
 
 (** {1 Comparison} *)
 

--- a/src/BwdNoLabels.ml
+++ b/src/BwdNoLabels.ml
@@ -68,6 +68,22 @@ let prepend xs ys =
       (go[@tailcall]) (xs, x :: ys)
   in go (xs, ys)
 
+let concat bs =
+  let[@tail_mod_cons] rec go bs =
+    function
+    | Emp ->
+      begin
+        match bs with
+        | Emp -> Emp
+        | Snoc (bs, b) -> (go[@tailcall]) bs b
+      end
+    | Snoc (xs, x) ->
+      Snoc ((go[@tailcall]) bs xs, x)
+  in
+  go bs Emp
+
+let flatten = concat
+
 let equal eq xs ys =
   let rec go =
     function

--- a/src/BwdNoLabels.mli
+++ b/src/BwdNoLabels.mli
@@ -43,6 +43,8 @@ val nth : 'a t -> int -> 'a
 val nth_opt : 'a t -> int -> 'a option
 val append : 'a t -> 'a list -> 'a t
 val prepend : 'a t -> 'a list -> 'a list
+val concat : 'a t t -> 'a t
+val flatten : 'a t t -> 'a t
 
 (** {1 Comparison} *)
 

--- a/test/ListAsBwdLabels.ml
+++ b/test/ListAsBwdLabels.ml
@@ -21,6 +21,10 @@ let append xs ys = xs @ ys
 
 let prepend xs ys = xs @ ys
 
+let concat = List.concat
+
+let flatten = List.flatten
+
 let equal ~eq xs ys = L.equal ~eq (L.rev xs) (L.rev ys)
 
 let compare ~cmp xs ys = L.compare ~cmp (L.rev xs) (L.rev ys)

--- a/test/TestBwdLabels.ml
+++ b/test/TestBwdLabels.ml
@@ -61,6 +61,14 @@ let test_prepend =
   Q.Test.make ~count ~name:"prepend" Q.Gen.(pair (small_list int) (small_list int))
     ~print:Q.Print.(pair (list int) (list int))
     (fun (xs, ys) -> B.prepend (of_list xs) ys = L.prepend xs ys)
+let test_concat =
+  Q.Test.make ~count ~name:"concat" Q.Gen.(small_list (small_list int))
+    ~print:Q.Print.(list (list int))
+    (fun ls -> to_list (B.concat (of_list (List.map ~f:of_list ls))) = L.concat ls)
+let test_flatten =
+  Q.Test.make ~count ~name:"flatten" Q.Gen.(small_list (small_list int))
+    ~print:Q.Print.(list (list int))
+    (fun ls -> to_list (B.flatten (of_list (List.map ~f:of_list ls))) = L.flatten ls)
 let test_equal =
   Q.Test.make ~count ~name:"equal"
     Q.Gen.(triple (Q.fun2 Q.Observable.int Q.Observable.int bool) (small_list small_int) (small_list small_int))
@@ -301,6 +309,8 @@ let () =
       test_nth_opt;
       test_append;
       test_prepend;
+      test_concat;
+      test_flatten;
       test_equal;
       test_compare;
       test_iter;


### PR DESCRIPTION
Close #18. My hesitation is whether the complex code to make it tail-recursive is worth it:
```ocaml
let concat bs =
  let[@tail_mod_cons] rec go bs =
    function
    | Emp ->
      begin
        match bs with
        | Emp -> Emp
        | Snoc (bs, b) -> (go[@tailcall]) bs b
      end
    | Snoc (xs, x) ->
      Snoc ((go[@tailcall]) bs xs, x)
  in
  go bs Emp
```